### PR TITLE
fix: clean up CI workflow for Vite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,11 @@ jobs:
       with:
         node-version: '22.x'
 
-    - name: FTP Deploy
+    - name: Build & FTP Deploy
       run: |
-        npm install
+        npm ci
         npm run deploy
       env:
-        CI: false
         FTP_USERNAME: ${{ secrets.FTP_USERNAME }}
         FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
         FTP_HOST: ${{ secrets.FTP_HOST }}


### PR DESCRIPTION
## Summary

- Remove `CI: false` — was a CRA-specific flag that suppressed ESLint warnings-as-errors; not needed with Vite
- Switch `npm install` → `npm ci` for reproducible, locked installs in CI
- Rename step from "FTP Deploy" to "Build & FTP Deploy" to reflect that `npm run deploy` runs `vite build` first

## Test plan
- [ ] Merge and verify the GitHub Actions workflow runs successfully on next push to master
